### PR TITLE
MYB-44 Obtain address from map geolocation

### DIFF
--- a/MyBus/MyBus/Info.plist
+++ b/MyBus/MyBus/Info.plist
@@ -54,5 +54,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>

--- a/MyBus/MyBus/Services/Connectivity.swift
+++ b/MyBus/MyBus/Services/Connectivity.swift
@@ -66,4 +66,39 @@ public class Connectivity: NSObject
         }
     }
     
+    public func getAddressFromCoordinate(latitude : Double, longitude: Double)
+    {
+        print("You tapped at: \(latitude), \(longitude)")
+        let addressFromCoordinateURLString = "\(coordinateToAddressEndpointURL)&latitud=\(latitude)&longitud=\(longitude)"
+        
+        let request = NSMutableURLRequest(URL: NSURL(string: addressFromCoordinateURLString)!)
+        request.HTTPMethod = "GET"
+        
+        Alamofire.request(request).responseJSON { (response) -> Void in
+            
+            if(response.result.isFailure)
+            {
+                print("\nError: \(response.result.error!)")
+            }
+            else
+            {
+                let resultValue = response.result.value!
+                
+                print(resultValue)
+                
+                var bodyData: NSData?
+                do
+                {
+                    bodyData = try NSJSONSerialization.dataWithJSONObject(resultValue, options: .PrettyPrinted)
+                    print(bodyData)
+                }
+                catch
+                {
+                    bodyData = nil
+                    print(error)
+                }
+            }
+        }
+    }
+    
 }

--- a/MyBus/MyBus/Services/Connectivity.swift
+++ b/MyBus/MyBus/Services/Connectivity.swift
@@ -66,7 +66,7 @@ public class Connectivity: NSObject
         }
     }
     
-    public func getAddressFromCoordinate(latitude : Double, longitude: Double)
+    public func getAddressFromCoordinate(latitude : Double, longitude: Double, completionHandler: (NSDictionary?, NSError?) -> ())
     {
         print("You tapped at: \(latitude), \(longitude)")
         let addressFromCoordinateURLString = "\(coordinateToAddressEndpointURL)&latitud=\(latitude)&longitud=\(longitude)"
@@ -74,29 +74,12 @@ public class Connectivity: NSObject
         let request = NSMutableURLRequest(URL: NSURL(string: addressFromCoordinateURLString)!)
         request.HTTPMethod = "GET"
         
-        Alamofire.request(request).responseJSON { (response) -> Void in
-            
-            if(response.result.isFailure)
-            {
-                print("\nError: \(response.result.error!)")
-            }
-            else
-            {
-                let resultValue = response.result.value!
-                
-                print(resultValue)
-                
-                var bodyData: NSData?
-                do
-                {
-                    bodyData = try NSJSONSerialization.dataWithJSONObject(resultValue, options: .PrettyPrinted)
-                    print(bodyData)
-                }
-                catch
-                {
-                    bodyData = nil
-                    print(error)
-                }
+        Alamofire.request(request).responseJSON { response in
+            switch response.result {
+            case .Success(let value):
+                completionHandler(value as? NSDictionary, nil)
+            case .Failure(let error):
+                completionHandler(nil, error)
             }
         }
     }

--- a/MyBus/MyBus/ViewController.swift
+++ b/MyBus/MyBus/ViewController.swift
@@ -20,11 +20,40 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         
         mapView.userTrackingMode = .Follow
         mapView.delegate = self
+        
+        // Double tapping zooms the map, so ensure that can still happen
+        let doubleTap = UITapGestureRecognizer(target: self, action: nil)
+        doubleTap.numberOfTapsRequired = 2
+        mapView.addGestureRecognizer(doubleTap)
+        
+        // Delay single tap recognition until it is clearly not a double
+        let singleTap = UITapGestureRecognizer(target: self, action: #selector(ViewController.handleSingleTap(_:)))
+        singleTap.requireGestureRecognizerToFail(doubleTap)
+        mapView.addGestureRecognizer(singleTap)
     }
     
     func mapView(mapView: MGLMapView, didUpdateUserLocation userLocation: MGLUserLocation?) {
         //Move map to current user location
         mapView.centerCoordinate = (userLocation!.location?.coordinate)!
+    }
+    
+    func handleSingleTap(tap: UITapGestureRecognizer) {
+        // Convert tap location (CGPoint) to geographic coordinates (CLLocationCoordinate2D)
+        let tappedLocation: CLLocationCoordinate2D = mapView.convertPoint(tap.locationInView(mapView), toCoordinateFromView: mapView)
+        
+        // Declare the marker point and set its coordinates
+        let mapPoint = MGLPointAnnotation()
+        mapPoint.coordinate = CLLocationCoordinate2D(latitude: tappedLocation.latitude, longitude: tappedLocation.longitude)
+        
+        // Remove first marker tapped from the map, add marker with coordinates
+        // Prevent having more than two points selected in map
+        if (mapView.annotations?.count != nil && mapView.annotations?.count > 1 ) {
+            mapView.removeAnnotation(mapView.annotations![0])
+        }
+        
+        // Add marker to the map
+        mapView.addAnnotation(mapPoint)
+        Connectivity.sharedInstance.getAddressFromCoordinate(tappedLocation.latitude, longitude: tappedLocation.longitude)
     }
 
     override func didReceiveMemoryWarning() {

--- a/MyBus/MyBus/ViewController.swift
+++ b/MyBus/MyBus/ViewController.swift
@@ -70,21 +70,33 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         // Convert tap location (CGPoint) to geographic coordinates (CLLocationCoordinate2D)
         let tappedLocation: CLLocationCoordinate2D = mapView.convertPoint(tap.locationInView(mapView), toCoordinateFromView: mapView)
         
-        // Declare the marker point and set its coordinates
-        let mapPoint = MGLPointAnnotation()
-        mapPoint.coordinate = CLLocationCoordinate2D(latitude: tappedLocation.latitude, longitude: tappedLocation.longitude)
-        
         // Remove first marker tapped from the map, add marker with coordinates
         // Prevent having more than two points selected in map
         if (mapView.annotations?.count != nil && mapView.annotations?.count > 1 ) {
             mapView.removeAnnotation(mapView.annotations![0])
         }
         
-        // Add marker to the map
-        mapView.addAnnotation(mapPoint)
-        Connectivity.sharedInstance.getAddressFromCoordinate(tappedLocation.latitude, longitude: tappedLocation.longitude)
-    }
+        Connectivity.sharedInstance.getAddressFromCoordinate(tappedLocation.latitude, longitude: tappedLocation.longitude) { responseObject, error in
+            let address = "\(responseObject!["calle"] as! String) \(responseObject!["altura"] as! String)"
+            
+            // Declare the marker point and set its coordinates
+            let mapPoint = MGLPointAnnotation()
+            mapPoint.coordinate = CLLocationCoordinate2D(latitude: tappedLocation.latitude, longitude: tappedLocation.longitude)
+            mapPoint.title = address
+            
+            // Add marker to the map
+            self.mapView.addAnnotation(mapPoint)
+            
+            // Pop-up the callout view
+            self.mapView.selectAnnotation(mapPoint, animated: true)
+        }
 
+    }
+    
+    func mapView(mapView: MGLMapView, annotationCanShowCallout annotation: MGLAnnotation) -> Bool{
+        return true
+    }
+    
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.

--- a/MyBus/MyBus/ViewController.swift
+++ b/MyBus/MyBus/ViewController.swift
@@ -50,10 +50,39 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(ViewController.offlinePackProgressDidChange(_:)), name: MGLOfflinePackProgressChangedNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(ViewController.offlinePackDidReceiveError(_:)), name: MGLOfflinePackProgressChangedNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(ViewController.offlinePackDidReceiveMaximumAllowedMapboxTiles(_:)), name: MGLOfflinePackProgressChangedNotification, object: nil)
+
+        // Double tapping zooms the map, so ensure that can still happen
+        let doubleTap = UITapGestureRecognizer(target: self, action: nil)
+        doubleTap.numberOfTapsRequired = 2
+        mapView.addGestureRecognizer(doubleTap)
+        
+        // Delay single tap recognition until it is clearly not a double
+        let singleTap = UITapGestureRecognizer(target: self, action: #selector(ViewController.handleSingleTap(_:)))
+        singleTap.requireGestureRecognizerToFail(doubleTap)
+        mapView.addGestureRecognizer(singleTap)
     }
     
     deinit {
         NSNotificationCenter.defaultCenter().removeObserver(self)
+    }
+    
+    func handleSingleTap(tap: UITapGestureRecognizer) {
+        // Convert tap location (CGPoint) to geographic coordinates (CLLocationCoordinate2D)
+        let tappedLocation: CLLocationCoordinate2D = mapView.convertPoint(tap.locationInView(mapView), toCoordinateFromView: mapView)
+        
+        // Declare the marker point and set its coordinates
+        let mapPoint = MGLPointAnnotation()
+        mapPoint.coordinate = CLLocationCoordinate2D(latitude: tappedLocation.latitude, longitude: tappedLocation.longitude)
+        
+        // Remove first marker tapped from the map, add marker with coordinates
+        // Prevent having more than two points selected in map
+        if (mapView.annotations?.count != nil && mapView.annotations?.count > 1 ) {
+            mapView.removeAnnotation(mapView.annotations![0])
+        }
+        
+        // Add marker to the map
+        mapView.addAnnotation(mapPoint)
+        Connectivity.sharedInstance.getAddressFromCoordinate(tappedLocation.latitude, longitude: tappedLocation.longitude)
     }
 
     override func didReceiveMemoryWarning() {


### PR DESCRIPTION
When user taps within the map, we retrieve belonging address (using MGP endpoint) then we add a marker with address as title.

![](http://s9.postimg.org/f11yr2u0f/tap.gif)
