### PR TITLE
Action on "Cancelar" bar button item

### DIFF
--- a/MyBus/MyBus/MainViewController.swift
+++ b/MyBus/MyBus/MainViewController.swift
@@ -175,7 +175,7 @@ class MainViewController: UIViewController{
     func configureNewSearchNavigation(){
         self.navigationItem.titleView = nil
         
-        let cancelButton = UIBarButtonItem(title: "Cancelar", style: UIBarButtonItemStyle.Plain, target: self, action: #selector(self.backTapped))
+        let cancelButton = UIBarButtonItem(title: "Cancelar", style: UIBarButtonItemStyle.Plain, target: self, action: #selector(self.clearActiveSearch))
         
         cancelButton.tintColor = UIColor.lightGrayColor()
         
@@ -213,7 +213,7 @@ class MainViewController: UIViewController{
     
     func clearActiveSearch(){
         self.mapViewModel.clearModel()
-        self.mapViewController.mapView.clearAllAnnotations()
+        self.mapViewController.resetMapSearch()
         self.initWithBasicSearch()
         self.configureMapNavigationInfo()        
     }

--- a/MyBus/MyBus/MapSearchViewContainer.swift
+++ b/MyBus/MyBus/MapSearchViewContainer.swift
@@ -39,8 +39,8 @@ class MapSearchViewContainer: UIView {
     }
     
     private func loadConcreteSearchView(aPresenter:SearchPresenter){
-        presenter = aPresenter
         clearViewSubviews()
+        presenter = aPresenter        
         addAutoPinnedSubview(presenter as! UIView, toView: self)
     }
     

--- a/MyBus/MyBus/MyBusMapController.swift
+++ b/MyBus/MyBus/MyBusMapController.swift
@@ -251,6 +251,13 @@ class MyBusMapController: UIViewController, MGLMapViewDelegate, UITableViewDeleg
     func clearRouteAnnotations(){
         self.mapView.clearExistingBusRouteAnnotations()
     }
+    
+    func resetMapSearch(){
+        self.mapView.clearAllAnnotations()
+        self.bestMatches = []
+        self.busResultsTableView.reloadData()
+        setBusResultsTableViewHeight(busResultTableHeightToHide)
+    }
 
     // MARK: - Pack Download
 


### PR DESCRIPTION
![searchcontainercleared](https://cloud.githubusercontent.com/assets/5022588/19280358/e5d91d7c-8fbb-11e6-8138-bb1eb7b0a7ce.gif)

MainViewController,
- Fixed action typo bug by setting "clearActiveSearch" instead of "backTapped" selector in "Cancelar" uibarbuttonitem

MapSearchViewContainer,
- Cleared the view's subviews before setting the presenter

MyBusMapController,
- Added resetMapSearch() method to clear annotations and busResults
