### PR TITLE
MYB-295 Now annotations are draggable

### DIFF
--- a/MyBus/MyBus.xcodeproj/project.pbxproj
+++ b/MyBus/MyBus.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		11A552811DA6B48F00CF4C95 /* MyBusMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A552801DA6B48F00CF4C95 /* MyBusMarker.swift */; };
 		11A552831DA6B6CB00CF4C95 /* MyBusMarkerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A552821DA6B6CB00CF4C95 /* MyBusMarkerFactory.swift */; };
 		11A552851DA6B70A00CF4C95 /* MyBusPolylineFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A552841DA6B70A00CF4C95 /* MyBusPolylineFactory.swift */; };
+		11C84AFD1DC1200400ACE925 /* MyBusMarkerAnnotationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C84AFC1DC1200400ACE925 /* MyBusMarkerAnnotationView.swift */; };
 		11D4BEE51D343B51005E0031 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D4BEE41D343B51005E0031 /* MainViewController.swift */; };
 		11DAE8FE1CC52EC600A35D6A /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DAE8FD1CC52EC600A35D6A /* Location.swift */; };
 		11DAE9021CC534D400A35D6A /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DAE9011CC534D400A35D6A /* User.swift */; };
@@ -128,6 +129,7 @@
 		11A552801DA6B48F00CF4C95 /* MyBusMarker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MyBusMarker.swift; sourceTree = "<group>"; };
 		11A552821DA6B6CB00CF4C95 /* MyBusMarkerFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MyBusMarkerFactory.swift; sourceTree = "<group>"; };
 		11A552841DA6B70A00CF4C95 /* MyBusPolylineFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MyBusPolylineFactory.swift; sourceTree = "<group>"; };
+		11C84AFC1DC1200400ACE925 /* MyBusMarkerAnnotationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MyBusMarkerAnnotationView.swift; sourceTree = "<group>"; };
 		11D4BEE41D343B51005E0031 /* MainViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		11DAE8FD1CC52EC600A35D6A /* Location.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Location.swift; path = Model/Location.swift; sourceTree = "<group>"; };
 		11DAE9011CC534D400A35D6A /* User.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = User.swift; path = Model/User.swift; sourceTree = "<group>"; };
@@ -326,6 +328,7 @@
 				11A552821DA6B6CB00CF4C95 /* MyBusMarkerFactory.swift */,
 				11A552841DA6B70A00CF4C95 /* MyBusPolylineFactory.swift */,
 				B455FA9B1DB1803500069F22 /* MyBusMapModel.swift */,
+				11C84AFC1DC1200400ACE925 /* MyBusMarkerAnnotationView.swift */,
 			);
 			name = UI;
 			sourceTree = "<group>";
@@ -682,6 +685,7 @@
 				C581F8021D9D562800DF6663 /* NavRouter.swift in Sources */,
 				11DFABEF1D424E1D002DC06E /* SearchSuggestionsDataSource.swift in Sources */,
 				C5B96F101D834D4A0073B990 /* BusesInformationTableViewCell.swift in Sources */,
+				11C84AFD1DC1200400ACE925 /* MyBusMarkerAnnotationView.swift in Sources */,
 				B47299431DA80B9B00D8D6D7 /* MapSearchViewContainer.swift in Sources */,
 				C5CE59D01D8AF572003A8FE4 /* RecentTableViewCell.swift in Sources */,
 				A0AFB0F21CCED92A001DD3B6 /* RoadResult.swift in Sources */,

--- a/MyBus/MyBus/MainViewController.swift
+++ b/MyBus/MyBus/MainViewController.swift
@@ -136,7 +136,7 @@ class MainViewController: UIViewController{
         NSLog("Origin dragged detected")
         let draggedOrigin: RoutePoint = self.getPropertyChangedFromNotification(notification) as! RoutePoint
         newOrigin(draggedOrigin)
-        verifySearchStatus(mapViewModel)
+        homeNavigationBar(mapViewModel)
     }
 
     func updateDraggedDestination(notification: NSNotification) {
@@ -148,7 +148,7 @@ class MainViewController: UIViewController{
 
     override func viewDidAppear(animated: Bool) {
         super.viewDidAppear(animated)
-        self.homeNavigationBar(mapViewModel)
+        homeNavigationBar(mapViewModel)
     }
 
     //This method receives the old view controller to be replaced with the new controller

--- a/MyBus/MyBus/MainViewController.swift
+++ b/MyBus/MyBus/MainViewController.swift
@@ -118,6 +118,32 @@ class MainViewController: UIViewController{
 
         self.mapViewModel = MapViewModel()
         self.mapViewModel.delegate = self
+
+        // Add observers
+        NSNotificationCenter.defaultCenter().removeObserver(self)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(updateDraggedOrigin), name:MyBusEndpointNotificationKey.originChanged.rawValue, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(updateDraggedDestination), name: MyBusEndpointNotificationKey.destinationChanged.rawValue, object: nil)
+
+    }
+
+
+    private func getPropertyChangedFromNotification(notification: NSNotification) -> AnyObject {
+        let userInfo: [String : AnyObject] = notification.userInfo as! [String:AnyObject]
+        return userInfo[MyBusMarkerAnnotationView.kPropertyChangedDescriptor]!
+    }
+
+    func updateDraggedOrigin(notification: NSNotification) {
+        NSLog("Origin dragged detected")
+        let draggedOrigin: RoutePoint = self.getPropertyChangedFromNotification(notification) as! RoutePoint
+        newOrigin(draggedOrigin)
+        verifySearchStatus(mapViewModel)
+    }
+
+    func updateDraggedDestination(notification: NSNotification) {
+        NSLog("Destination dragged detected")
+        let draggedDestination: RoutePoint = self.getPropertyChangedFromNotification(notification) as! RoutePoint
+        newDestination(draggedDestination)
+        verifySearchStatus(mapViewModel)
     }
 
     override func viewDidAppear(animated: Bool) {

--- a/MyBus/MyBus/MyBusMapController.swift
+++ b/MyBus/MyBus/MyBusMapController.swift
@@ -280,6 +280,14 @@ class MyBusMapController: UIViewController, MGLMapViewDelegate, UITableViewDeleg
         GenerateMessageAlert.generateAlertToSetting(self)
     }
 
+    func mapView(mapView: MGLMapView, viewForAnnotation annotation: MGLAnnotation) -> MGLAnnotationView? {
+        guard annotation is MyBusMarker else {
+            return nil
+        }
+        return (annotation as! MyBusMarker).markerView
+
+    }
+
     // MARK: - Mapview bus roads manipulation Methods
     func addBusLinesResults(busRouteOptions: [BusRouteResult], preselectedRouteIndex: Int = 0){
 

--- a/MyBus/MyBus/MyBusMapController.swift
+++ b/MyBus/MyBus/MyBusMapController.swift
@@ -154,38 +154,30 @@ class MyBusMapController: UIViewController, MGLMapViewDelegate, UITableViewDeleg
      This method sets the button of the annotation
      */
     func mapView(mapView: MGLMapView, leftCalloutAccessoryViewForAnnotation annotation: MGLAnnotation) -> UIView? {
-        let annotationTitle = annotation.title!! as String
-        // Only display button when marker is with Destino title
-        let address = annotation.coordinate
-        if (existFavoritePlace(address)) {
-            if annotationTitle == MyBusTitle.DestinationTitle.rawValue {
-                let button = UIButton(type: .DetailDisclosure)
-                button.setImage(UIImage(named: "tabbar_favourite_fill"), forState: UIControlState.Normal)
-                button.tag = 0
-                return button
-            }
-        } else {
-            if annotationTitle == MyBusTitle.DestinationTitle.rawValue {
-                let button = UIButton(type: .DetailDisclosure)
-                button.setImage(UIImage(named: "tabbar_favourite_line"), forState: UIControlState.Normal)
-                button.tag = 1
-                return button
-            }
+        guard (annotation is MyBusMarkerDestinationPoint || annotation is MyBusMarkerOriginPoint) else {
+            return nil
         }
-        return nil
+        let locationCoordinate = annotation.coordinate
+        let alreadyIsFavorite = existFavoritePlace(locationCoordinate)
+        let buttonImage = alreadyIsFavorite ? UIImage(named: "tabbar_favourite_fill") : UIImage(named: "tabbar_favourite_line")
+        
+        let button = UIButton(type: .DetailDisclosure)
+        button.setImage(buttonImage, forState: UIControlState.Normal)
+        button.tag = alreadyIsFavorite ? 0 : 1
+        return button
     }
     
-    func mapView(mapView: MGLMapView, rightCalloutAccessoryViewForAnnotation annotation: MGLAnnotation) -> UIView? {
-        let annotationTitle = annotation.title!! as String
-        // Only display button when marker is with Destino title
-        if annotationTitle == MyBusTitle.DestinationTitle.rawValue {
-            let button = UIButton(type: .DetailDisclosure)
-            button.setImage(UIImage(named: "tabbar_route_fill"), forState: UIControlState.Normal)
-            button.tag = 2
-            return button
-        }
-        return nil
-    }
+//    func mapView(mapView: MGLMapView, rightCalloutAccessoryViewForAnnotation annotation: MGLAnnotation) -> UIView? {
+//        let annotationTitle = annotation.title!! as String
+//        // Only display button when marker is with Destino title
+//        if annotationTitle == MyBusTitle.DestinationTitle.rawValue {
+//            let button = UIButton(type: .DetailDisclosure)
+//            button.setImage(UIImage(named: "tabbar_route_fill"), forState: UIControlState.Normal)
+//            button.tag = 2
+//            return button
+//        }
+//        return nil
+//    }
     
     /**
      This method makes the search when the button is pressed on the annotation

--- a/MyBus/MyBus/MyBusMapController.swift
+++ b/MyBus/MyBus/MyBusMapController.swift
@@ -281,11 +281,15 @@ class MyBusMapController: UIViewController, MGLMapViewDelegate, UITableViewDeleg
     }
 
     func mapView(mapView: MGLMapView, viewForAnnotation annotation: MGLAnnotation) -> MGLAnnotationView? {
-        guard annotation is MyBusMarker else {
+        guard let myBusMarker = annotation as? MyBusMarker else {
             return nil
         }
-        return (annotation as! MyBusMarker).markerView
 
+        if let annotationView = mapView.dequeueReusableAnnotationViewWithIdentifier(myBusMarker.markerImageIdentifier!) {
+            return annotationView
+        } else {
+            return myBusMarker.markerView
+        }
     }
 
     // MARK: - Mapview bus roads manipulation Methods
@@ -503,7 +507,4 @@ class MyBusMapController: UIViewController, MGLMapViewDelegate, UITableViewDeleg
         mapRoute.polyline = MyBusPolylineFactory.buildCompleteBusRoutePolylineList(newRoute)
         self.mapModel.completeBusRoute = mapRoute
     }
-
-
-
 }

--- a/MyBus/MyBus/MyBusMapController.swift
+++ b/MyBus/MyBus/MyBusMapController.swift
@@ -97,37 +97,6 @@ class MyBusMapController: UIViewController, MGLMapViewDelegate, UITableViewDeleg
         return true
     }
     
-    func searchBusRoad(annotation: MGLAnnotation) {
-        //Make the search
-        let locationServiceAuth = CLLocationManager.authorizationStatus()
-        //If origin location is diferent nil
-        if (locationServiceAuth == .AuthorizedAlways || locationServiceAuth == .AuthorizedWhenInUse) {
-            if let originLocation = self.mapView.currentGPSLocation()?.coordinate {
-                self.mapView.addAnnotation(annotation)
-                Connectivity.sharedInstance.getAddressFromCoordinate(originLocation.latitude, longitude: originLocation.longitude) { (routePoint, error) in
-                    if let origin = routePoint {
-                        self.updateOrigin(origin)
-                        SearchManager.sharedInstance.search(origin, destination:self.destination!, completionHandler: {
-                            (busRouteResult, error) in
-                            self.progressNotification.stopLoadingNotification(self.view)
-                            if let results = busRouteResult where results.hasRouteOptions {
-                                self.addBusLinesResults(results.busRouteOptions)
-                            }else{
-                                GenerateMessageAlert.generateAlert(self, title: "Malas noticias 😿", message: "Lamentablemente no pudimos resolver tu consulta. Al parecer las ubicaciones son muy cercanas ")
-                            }
-                        })
-                    }
-                }
-            } else {
-                self.mapView.showsUserLocation = true
-                self.progressNotification.stopLoadingNotification(self.view)
-            }
-        } else {
-            self.progressNotification.stopLoadingNotification(self.view)
-            GenerateMessageAlert.generateAlertToSetting(self)
-        }
-    }
-    
     func existFavoritePlace(address: CLLocationCoordinate2D) -> Bool {
         if let favorites = DBManager.sharedInstance.getFavourites(){
             let filter  = favorites.filter{($0.latitude) == address.latitude && ($0.longitude) == address.longitude}
@@ -167,18 +136,6 @@ class MyBusMapController: UIViewController, MGLMapViewDelegate, UITableViewDeleg
         return button
     }
     
-//    func mapView(mapView: MGLMapView, rightCalloutAccessoryViewForAnnotation annotation: MGLAnnotation) -> UIView? {
-//        let annotationTitle = annotation.title!! as String
-//        // Only display button when marker is with Destino title
-//        if annotationTitle == MyBusTitle.DestinationTitle.rawValue {
-//            let button = UIButton(type: .DetailDisclosure)
-//            button.setImage(UIImage(named: "tabbar_route_fill"), forState: UIControlState.Normal)
-//            button.tag = 2
-//            return button
-//        }
-//        return nil
-//    }
-    
     /**
      This method makes the search when the button is pressed on the annotation
      */
@@ -206,9 +163,6 @@ class MyBusMapController: UIViewController, MGLMapViewDelegate, UITableViewDeleg
             DBManager.sharedInstance.addFavorite(location)})
             alert.addAction(UIAlertAction(title: "Cancelar", style: UIAlertActionStyle.Cancel, handler: nil))
             self.presentViewController(alert, animated: true, completion: nil)
-            
-        case 2:
-            self.searchBusRoad(annotation)
         default: break
         }
     }

--- a/MyBus/MyBus/MyBusMapController.swift
+++ b/MyBus/MyBus/MyBusMapController.swift
@@ -57,16 +57,6 @@ class MyBusMapController: UIViewController, MGLMapViewDelegate, UITableViewDeleg
         NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(MyBusMapController.offlinePackProgressDidChange(_:)), name: MGLOfflinePackProgressChangedNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(MyBusMapController.offlinePackDidReceiveError(_:)), name: MGLOfflinePackProgressChangedNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(MyBusMapController.offlinePackDidReceiveMaximumAllowedMapboxTiles(_:)), name: MGLOfflinePackProgressChangedNotification, object: nil)
-
-        // Double tapping zooms the map, so ensure that can still happen
-        let doubleTap = UITapGestureRecognizer(target: self, action: nil)
-        doubleTap.numberOfTapsRequired = 2
-        mapView.addGestureRecognizer(doubleTap)
-
-        // Delay single tap recognition until it is clearly not a double
-        let singleLongTap = UILongPressGestureRecognizer(target: self, action: #selector(MyBusMapController.handleSingleLongTap(_:)))
-        singleLongTap.requireGestureRecognizerToFail(doubleTap)
-        mapView.addGestureRecognizer(singleLongTap)
     }
 
     // MARK: - Tapping Methods
@@ -82,28 +72,6 @@ class MyBusMapController: UIViewController, MGLMapViewDelegate, UITableViewDeleg
         } else {
             GenerateMessageAlert.generateAlertToSetting(self)
         }
-    }
-
-    func handleSingleLongTap(tap: UITapGestureRecognizer) {
-        if (tap.state == .Ended) {
-            NSLog("Long press Ended")
-        } else if (tap.state == .Began) {
-            mapView.showsUserLocation = true
-            // Convert tap location (CGPoint) to geographic coordinates (CLLocationCoordinate2D)
-            let tappedLocation = mapView.convertPoint(tap.locationInView(mapView), toCoordinateFromView: mapView)
-
-            progressNotification.showLoadingNotification(self.view)
-
-            Connectivity.sharedInstance.getAddressFromCoordinate(tappedLocation.latitude, longitude: tappedLocation.longitude) { (routePoint, error) in
-                if let destination = routePoint {
-                    self.destination = destination
-                    self.updateDestination(destination)
-                    self.mapView.selectDestinationMarker()
-                }
-                self.progressNotification.stopLoadingNotification(self.view)
-            }
-        }
-
     }
 
     // MARK: - Memory Management Methods

--- a/MyBus/MyBus/MyBusMapView.swift
+++ b/MyBus/MyBus/MyBusMapView.swift
@@ -117,7 +117,7 @@ class MyBusMapView: MGLMapView{
         removeOriginPoint()
         addAnnotation(newOrigin)
         setCenterCoordinate(newOrigin.coordinate, animated: true)
-        
+        selectMyBusAnnotation(newOrigin)
     }
     
     func addDestinationPoint(notification:NSNotification){
@@ -127,6 +127,7 @@ class MyBusMapView: MGLMapView{
         removeDestinationPoint()
         addAnnotation(newDestination)
         fitToAnnotationsInMap()
+        selectMyBusAnnotation(newDestination)
     }
     
     func addRoad(notification:NSNotification){
@@ -169,18 +170,20 @@ class MyBusMapView: MGLMapView{
         self.setZoomLevel(16, animated: false)
     }
 
-    
-    func selectDestinationMarker() -> Void {
-        if let annotations = self.annotations {
-            for annotation in annotations {
-                if annotation.title! == MyBusTitle.DestinationTitle.rawValue {
-                    self.setCenterCoordinate(annotation.coordinate, zoomLevel: 14, animated: false)
-                    self.selectAnnotation(annotation, animated: false)
-                }
-            }
-        }
+    func selectMyBusAnnotation(annotation: MyBusMarker) {
+        //To prevent marker from displaying marker callout in a different position
+        let seconds = 0.6
+        let delay = seconds * Double(NSEC_PER_SEC)  // nanoseconds per seconds
+        let dispatchTime = dispatch_time(DISPATCH_TIME_NOW, Int64(delay))
+        
+        dispatch_after(dispatchTime, dispatch_get_main_queue(), {
+            
+            // here code perfomed with delay
+            self.selectAnnotation(annotation, animated: false)
+            
+        })
     }
-
+    
     // MARK: - Mapview bus roads manipulation Methods
     
     func fitToAnnotationsInMap() -> Void {

--- a/MyBus/MyBus/MyBusMarker.swift
+++ b/MyBus/MyBus/MyBusMarker.swift
@@ -34,13 +34,11 @@ class MyBusMarker: MGLPointAnnotation {
     }
     var markerView: MGLAnnotationView? {
         get {
-            guard let identifier = markerImageIdentifier else { return nil }
-            if var image = UIImage(named: identifier) {
-                return MyBusMarkerAnnotationView(reuseIdentifier: identifier)
-            }
-            return nil
+            guard let identifier = markerImageIdentifier where (self is MyBusMarkerOriginPoint || self is MyBusMarkerDestinationPoint) else { return nil }
+            return MyBusMarkerAnnotationView(reuseIdentifier: identifier)
         }
     }
+
 
     // MARK: MyBusMarker Constructor
     init(position: CLLocationCoordinate2D, title: String, subtitle: String? = "", imageIdentifier: String?) {

--- a/MyBus/MyBus/MyBusMarker.swift
+++ b/MyBus/MyBus/MyBusMarker.swift
@@ -10,7 +10,6 @@ import Foundation
 import Mapbox
 import UIKit
 
-//class MyBusMarkerAddressPoint: MyBusMarker {}
 class MyBusMarkerOriginPoint: MyBusMarker {}
 class MyBusMarkerDestinationPoint: MyBusMarker {}
 class MyBusMarkerBusStopPoint: MyBusMarker{}
@@ -29,6 +28,15 @@ class MyBusMarker: MGLPointAnnotation {
             if var image = UIImage(named: identifier) {
                 image = image.imageWithAlignmentRectInsets(UIEdgeInsetsMake(0, 0, image.size.height/2, 0))
                 return MGLAnnotationImage(image: image, reuseIdentifier: identifier)
+            }
+            return nil
+        }
+    }
+    var markerView: MGLAnnotationView? {
+        get {
+            guard let identifier = markerImageIdentifier else { return nil }
+            if var image = UIImage(named: identifier) {
+                return MyBusMarkerAnnotationView(reuseIdentifier: identifier)
             }
             return nil
         }

--- a/MyBus/MyBus/MyBusMarkerAnnotationView.swift
+++ b/MyBus/MyBus/MyBusMarkerAnnotationView.swift
@@ -21,12 +21,13 @@ class MyBusMarkerAnnotationView: MGLAnnotationView {
         super.init(reuseIdentifier: reuseIdentifier)
         draggable = true
         scalesWithViewingDistance = false
-        var image = UIImage(named: reuseIdentifier)
-        image =  image!.imageWithAlignmentRectInsets(UIEdgeInsetsMake(0, 0, image!.size.height/2, 0))
-        let imageView = UIImageView(image: image)
-        self.frame = imageView.frame
-        self.backgroundColor = .clearColor()
-        self.addSubview(imageView)
+        if var image = UIImage(named: reuseIdentifier) {
+            image =  image.imageWithAlignmentRectInsets(UIEdgeInsetsMake(0, 0, image.size.height/2, 0))
+            let imageView = UIImageView(image: image)
+            self.frame = imageView.frame
+            self.backgroundColor = .clearColor()
+            self.addSubview(imageView)
+        }
     }
 
     // These two initializers are forced upon us by Swift.
@@ -44,12 +45,10 @@ class MyBusMarkerAnnotationView: MGLAnnotationView {
 
         switch dragState {
         case .Starting:
-            print("Starting", terminator: "")
             startDragging()
         case .Dragging:
             print(".", terminator: "")
         case .Ending, .Canceling:
-            print("Ending")
             endDragging()
         case .None:
             return

--- a/MyBus/MyBus/MyBusMarkerAnnotationView.swift
+++ b/MyBus/MyBus/MyBusMarkerAnnotationView.swift
@@ -8,7 +8,15 @@
 
 import Mapbox
 
+enum MyBusEndpointNotificationKey: String {
+    case originChanged = "markerOriginEndDragged"
+    case destinationChanged = "markerDestinationEndDragged"
+}
+
 class MyBusMarkerAnnotationView: MGLAnnotationView {
+
+    static let kPropertyChangedDescriptor: String = "MapPropertyChanged"
+
     init(reuseIdentifier: String, size: CGFloat? = 30.0) {
         super.init(reuseIdentifier: reuseIdentifier)
         draggable = true
@@ -68,8 +76,23 @@ class MyBusMarkerAnnotationView: MGLAnnotationView {
             Connectivity.sharedInstance.getAddressFromCoordinate(newCoordinate.latitude, longitude: newCoordinate.longitude) { (routePoint, error) in
                 if let newPoint = routePoint {
                     print(newPoint.address)
+                    if annotation is MyBusMarkerOriginPoint {
+                        self.notifyPropertyChanged(MyBusEndpointNotificationKey.originChanged, object: newPoint)
+                    } else if annotation is MyBusMarkerDestinationPoint {
+                        self.notifyPropertyChanged(MyBusEndpointNotificationKey.destinationChanged, object: newPoint)
+                    }
                 }
             }
+        }
+    }
+
+    private func notifyPropertyChanged(propertyKey: MyBusEndpointNotificationKey, object: AnyObject?){
+        if object == nil {
+            // Don't send the notification if the property has been set to nil
+            NSLog("\(propertyKey.rawValue) is now nil")
+        } else {
+            NSNotificationCenter.defaultCenter().postNotificationName(propertyKey.rawValue, object: nil, userInfo: [MyBusMarkerAnnotationView.kPropertyChangedDescriptor
+                :object!])
         }
     }
 }

--- a/MyBus/MyBus/MyBusMarkerAnnotationView.swift
+++ b/MyBus/MyBus/MyBusMarkerAnnotationView.swift
@@ -71,16 +71,10 @@ class MyBusMarkerAnnotationView: MGLAnnotationView {
             }, completion: nil)
 
         if let annotation = self.annotation {
-            let newCoordinate = annotation.coordinate
-            Connectivity.sharedInstance.getAddressFromCoordinate(newCoordinate.latitude, longitude: newCoordinate.longitude) { (routePoint, error) in
-                if let newPoint = routePoint {
-                    print(newPoint.address)
-                    if annotation is MyBusMarkerOriginPoint {
-                        self.notifyPropertyChanged(MyBusEndpointNotificationKey.originChanged, object: newPoint)
-                    } else if annotation is MyBusMarkerDestinationPoint {
-                        self.notifyPropertyChanged(MyBusEndpointNotificationKey.destinationChanged, object: newPoint)
-                    }
-                }
+            if annotation is MyBusMarkerOriginPoint {
+                self.notifyPropertyChanged(MyBusEndpointNotificationKey.originChanged, object: annotation)
+            } else if annotation is MyBusMarkerDestinationPoint {
+                self.notifyPropertyChanged(MyBusEndpointNotificationKey.destinationChanged, object: annotation)
             }
         }
     }

--- a/MyBus/MyBus/MyBusMarkerAnnotationView.swift
+++ b/MyBus/MyBus/MyBusMarkerAnnotationView.swift
@@ -1,0 +1,66 @@
+//
+//  MyBusMarkerAnnotationView.swift
+//  MyBus
+//
+//  Created by Lisandro Falconi on 10/26/16.
+//  Copyright © 2016 Spark Digital. All rights reserved.
+//
+
+import Mapbox
+
+class MyBusMarkerAnnotationView: MGLAnnotationView {
+    init(reuseIdentifier: String, size: CGFloat? = 30.0) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        draggable = true
+        scalesWithViewingDistance = false
+        var image = UIImage(named: reuseIdentifier)
+        image =  image!.imageWithAlignmentRectInsets(UIEdgeInsetsMake(0, 0, image!.size.height/2, 0))
+        let imageView = UIImageView(image: image)
+        self.frame = imageView.frame
+        self.backgroundColor = .clearColor()
+        self.addSubview(imageView)
+    }
+
+    // These two initializers are forced upon us by Swift.
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // Custom handler for changes in the annotation’s drag state.
+    override func setDragState(dragState: MGLAnnotationViewDragState, animated: Bool) {
+        super.setDragState(dragState, animated: animated)
+
+        switch dragState {
+        case .Starting:
+            print("Starting", terminator: "")
+            startDragging()
+        case .Dragging:
+            print(".", terminator: "")
+        case .Ending, .Canceling:
+            print("Ending")
+            endDragging()
+        case .None:
+            return
+        }
+    }
+
+    // When the user interacts with an annotation, animate opacity and scale changes.
+    func startDragging() {
+        UIView.animateWithDuration(0.3, delay: 0, usingSpringWithDamping: 0.5, initialSpringVelocity: 0, options: [], animations: {
+            self.layer.opacity = 0.8
+            self.transform = CGAffineTransformScale(CGAffineTransformIdentity, 1.5, 1.5)
+            }, completion: nil)
+    }
+
+    func endDragging() {
+        transform = CGAffineTransformScale(CGAffineTransformIdentity, 1.5, 1.5)
+        UIView.animateWithDuration(0.3, delay: 0, usingSpringWithDamping: 0.5, initialSpringVelocity: 0, options: [], animations: {
+            self.layer.opacity = 1
+            self.transform = CGAffineTransformScale(CGAffineTransformIdentity, 1, 1)
+            }, completion: nil)
+    }
+}

--- a/MyBus/MyBus/MyBusMarkerAnnotationView.swift
+++ b/MyBus/MyBus/MyBusMarkerAnnotationView.swift
@@ -62,5 +62,14 @@ class MyBusMarkerAnnotationView: MGLAnnotationView {
             self.layer.opacity = 1
             self.transform = CGAffineTransformScale(CGAffineTransformIdentity, 1, 1)
             }, completion: nil)
+
+        if let annotation = self.annotation {
+            let newCoordinate = annotation.coordinate
+            Connectivity.sharedInstance.getAddressFromCoordinate(newCoordinate.latitude, longitude: newCoordinate.longitude) { (routePoint, error) in
+                if let newPoint = routePoint {
+                    print(newPoint.address)
+                }
+            }
+        }
     }
 }

--- a/MyBus/MyBus/MyBusMarkerAnnotationView.swift
+++ b/MyBus/MyBus/MyBusMarkerAnnotationView.swift
@@ -24,7 +24,7 @@ class MyBusMarkerAnnotationView: MGLAnnotationView {
         if var image = UIImage(named: reuseIdentifier) {
             image =  image.imageWithAlignmentRectInsets(UIEdgeInsetsMake(0, 0, image.size.height/2, 0))
             let imageView = UIImageView(image: image)
-            self.frame = imageView.frame
+            self.frame = CGRectMake(0, 0, image.size.width + 5, image.size.height + 5)
             self.backgroundColor = .clearColor()
             self.addSubview(imageView)
         }

--- a/MyBus/MyBus/SearchContainerViewController.swift
+++ b/MyBus/MyBus/SearchContainerViewController.swift
@@ -170,10 +170,7 @@ extension SearchContainerViewController:UISearchBarDelegate {
             let message = "El campo \(self.searchType.rawValue) no esta indicado"
             GenerateMessageAlert.generateAlert(self, title: "No sabemos que buscar", message: message)
         }
-
     }
-
-
 }
 
 

--- a/MyBus/MyBus/SearchContainerViewController.swift
+++ b/MyBus/MyBus/SearchContainerViewController.swift
@@ -190,7 +190,7 @@ extension SearchContainerViewController:MainViewDelegate{
         }
     }
 
-    func loadPostionFromFavsRecents(position: RoutePoint) {
+    func loadPositionFromFavsRecents(position: RoutePoint) {
         if self.searchType == SearchType.Origin {
             self.busRoadDelegate?.newOrigin(position)
         }else{

--- a/MyBus/MyBus/SearchViewController.swift
+++ b/MyBus/MyBus/SearchViewController.swift
@@ -24,7 +24,7 @@ protocol MapBusRoadDelegate {
 
 protocol MainViewDelegate: class {
     func loadPositionMainView()
-    func loadPostionFromFavsRecents(position: RoutePoint)
+    func loadPositionFromFavsRecents(position: RoutePoint)
 }
 
 class SearchViewController: UIViewController, UITableViewDelegate
@@ -70,10 +70,10 @@ class SearchViewController: UIViewController, UITableViewDelegate
         switch indexPath.section {
         case 0:
             let selectedRecent = self.streetSuggestionsDataSource.recents[indexPath.row]
-            self.mainViewDelegate?.loadPostionFromFavsRecents(selectedRecent)
+            self.mainViewDelegate?.loadPositionFromFavsRecents(selectedRecent)
         case 1:
             let selectedFavourite = self.streetSuggestionsDataSource.favourites[indexPath.row]
-            self.mainViewDelegate?.loadPostionFromFavsRecents(selectedFavourite)
+            self.mainViewDelegate?.loadPositionFromFavsRecents(selectedFavourite)
         default:
             break
         }

--- a/MyBus/MyBus/Services/GisService.swift
+++ b/MyBus/MyBus/Services/GisService.swift
@@ -32,9 +32,10 @@ public class GisService: NSObject, GisServiceDelegate {
     func getAddressFromCoordinate(latitude: Double, longitude: Double, completionHandler: (RoutePoint?, NSError?) -> ())
     {
         print("You tapped at: \(latitude), \(longitude)")
+        let validLocalities = ["general pueyrredón", "mar del plata", "sierra de los padres", "batán"]
         CLGeocoder().reverseGeocodeLocation(CLLocation(latitude: latitude, longitude: longitude)) {
             placemarks, error in
-            guard let placemark = placemarks?.first where (placemark.locality == "General Pueyrredón" || placemark.locality == "Mar del Plata" || placemark.locality == "Sierra de los Padres" || placemark.locality == "Batán") else {
+            guard let placemark = placemarks?.first, let locality = placemark.locality where validLocalities.contains(locality.lowercaseString) else {
                 return completionHandler(nil, error)
             }
 
@@ -46,6 +47,8 @@ public class GisService: NSObject, GisServiceDelegate {
                 let house = (houseNumber as String).componentsSeparatedByString("–").first! ?? ""
                 let address = "\(streetName) \(house)"
                 point.address = address
+            } else {
+                point.address = locality
             }
             completionHandler(point, nil)
         }

--- a/MyBus/MyBus/Services/GisService.swift
+++ b/MyBus/MyBus/Services/GisService.swift
@@ -34,21 +34,20 @@ public class GisService: NSObject, GisServiceDelegate {
         print("You tapped at: \(latitude), \(longitude)")
         CLGeocoder().reverseGeocodeLocation(CLLocation(latitude: latitude, longitude: longitude)) {
             placemarks, error in
-            if let placemark = placemarks?.first {
-                let point = RoutePoint()
-                point.latitude = latitude
-                point.longitude = longitude
-                if let street = placemark.thoroughfare, let houseNumber = placemark.subThoroughfare {
-                    let streetName = (street as String).stringByReplacingOccurrencesOfString("Calle ", withString: "")
-                    let house = (houseNumber as String).componentsSeparatedByString("–").first! ?? ""
-                    let address = "\(streetName) \(house)"
-                    point.address = address
-                }
-                completionHandler(point, nil)
-            }else{
-                completionHandler(nil, error)
+            guard let placemark = placemarks?.first where (placemark.locality == "General Pueyrredón" || placemark.locality == "Mar del Plata" || placemark.locality == "Sierra de los Padres" || placemark.locality == "Batán") else {
+                return completionHandler(nil, error)
             }
-            
+
+            let point = RoutePoint()
+            point.latitude = latitude
+            point.longitude = longitude
+            if let street = placemark.thoroughfare, let houseNumber = placemark.subThoroughfare {
+                let streetName = (street as String).stringByReplacingOccurrencesOfString("Calle ", withString: "")
+                let house = (houseNumber as String).componentsSeparatedByString("–").first! ?? ""
+                let address = "\(streetName) \(house)"
+                point.address = address
+            }
+            completionHandler(point, nil)
         }
     }
 }

--- a/MyBus/MyBus/Services/GisService.swift
+++ b/MyBus/MyBus/Services/GisService.swift
@@ -39,7 +39,9 @@ public class GisService: NSObject, GisServiceDelegate {
                 point.latitude = latitude
                 point.longitude = longitude
                 if let street = placemark.thoroughfare, let houseNumber = placemark.subThoroughfare {
-                    let address = "\(street as String) \(houseNumber as String)"
+                    let streetName = (street as String).stringByReplacingOccurrencesOfString("Calle ", withString: "")
+                    let house = (houseNumber as String).componentsSeparatedByString("–").first! ?? ""
+                    let address = "\(streetName) \(house)"
                     point.address = address
                 }
                 completionHandler(point, nil)

--- a/MyBus/MyBus/SuggestionSearchViewController.swift
+++ b/MyBus/MyBus/SuggestionSearchViewController.swift
@@ -156,11 +156,11 @@ class SuggestionSearchViewController: UIViewController, UITableViewDelegate, UIS
         
         if let result: SuggestionProtocol = self.bestMatches[indexPath.row] {
             if let recentSelected = result as? RecentSuggestion {
-                self.mainViewDelegate?.loadPostionFromFavsRecents(recentSelected.getPoint())
+                self.mainViewDelegate?.loadPositionFromFavsRecents(recentSelected.getPoint())
             } else if let placeSelected = result as? SuggestedPlace {
-                self.mainViewDelegate?.loadPostionFromFavsRecents(placeSelected.getPoint())
+                self.mainViewDelegate?.loadPositionFromFavsRecents(placeSelected.getPoint())
             } else if let favSelected = result as? FavoriteSuggestion {
-                self.mainViewDelegate?.loadPostionFromFavsRecents(favSelected.getPoint())
+                self.mainViewDelegate?.loadPositionFromFavsRecents(favSelected.getPoint())
             } else {
                 self.searchBar?.text = "\(result.name) "
             }


### PR DESCRIPTION
Note: In addition story feature done, this PR involves multiples fixes and improvements
- Origin and destination markers has MyBusMarkerAnnotationView to be draggable
- When a marker is dragged and dropped, it updates current search
- Long press in map now add origin or destination (if origin is already set) in search
- Beautified reverse geocoding form MapKit address format
- Removed bus button as right callout accessory

[GIF](http://i.imgur.com/1DaRfne.gifv)
