### PR TITLE
MYB-404: Change the 'recientes' saving Policy

### DIFF
--- a/MyBus/MyBus/MainViewController.swift
+++ b/MyBus/MyBus/MainViewController.swift
@@ -327,7 +327,9 @@ class MainViewController: UIViewController {
         if self.mapViewModel.hasOrigin && self.mapViewModel.hasDestiny {
             self.progressNotification.showLoadingNotification(self.view)
             SearchManager.sharedInstance.search(mapViewModel.origin!, destination: mapViewModel.destiny!, completionHandler: { (searchResult, error) in
-
+                
+                DBManager.sharedInstance.addRecent(self.mapViewModel.origin!)
+                DBManager.sharedInstance.addRecent(self.mapViewModel.destiny!)
                 self.progressNotification.stopLoadingNotification(self.view)
 
                 if let r: BusSearchResult = searchResult {

--- a/MyBus/MyBus/SearchContainerViewController.swift
+++ b/MyBus/MyBus/SearchContainerViewController.swift
@@ -147,8 +147,6 @@ extension SearchContainerViewController:UISearchBarDelegate {
                 self.progressNotification.stopLoadingNotification(self.view)
 
                 if let p = point {
-                    DBManager.sharedInstance.addRecent(p)
-
                     if self.searchType == SearchType.Origin {
                         self.busRoadDelegate?.newOrigin(p)
                     }else{


### PR DESCRIPTION
This implements bug https://devspark-com.atlassian.net/browse/MYB-404 in which basically the policy for managing 'recientes' is changed. Now the 'recientes' are stored once the user has indeed used them.