### PR TITLE
Myb 409 nav bar disappear on drag drop

### DIFF
--- a/MyBus/MyBus/MainViewController.swift
+++ b/MyBus/MyBus/MainViewController.swift
@@ -564,6 +564,7 @@ extension MainViewController {
         self.currentViewController = self.mapViewController
 
         self.tabBar.selectedItem = self.tabBar.items?[0]
+        self.navigationController?.setNavigationBarHidden(false, animated: false)
     }
 
     func verifySearchStatus(mapModel: MapViewModel){

--- a/MyBus/MyBus/MyBusMapController.swift
+++ b/MyBus/MyBus/MyBusMapController.swift
@@ -337,6 +337,7 @@ class MyBusMapController: UIViewController, MGLMapViewDelegate, BusesResultsMenu
         if let origin = newOrigin {
             let marker = MyBusMarkerFactory.createOriginPointMarker(origin)
             self.mapModel.originMarker = marker
+            self.mapModel.currentRoad = nil
         }else{
             self.mapView.removeOriginPoint()
             self.mapModel.originMarker = nil
@@ -355,6 +356,7 @@ class MyBusMapController: UIViewController, MGLMapViewDelegate, BusesResultsMenu
         if let destination = newDestination {
             let marker = MyBusMarkerFactory.createDestinationPointMarker(destination)
             self.mapModel.destinationMarker = marker
+            self.mapModel.currentRoad = nil
         }else{
             self.mapView.removeDestinationPoint()
             self.mapModel.destinationMarker = nil

--- a/MyBus/MyBus/MyBusMapView.swift
+++ b/MyBus/MyBus/MyBusMapView.swift
@@ -279,24 +279,25 @@ class MyBusMapView: MGLMapView{
             case first = 1.2
             case second = 1.8
             case third = 2.8
-            case fourth = 3.5
+            case fourth = 4.0 //previous: 3.5
             case fifth = 4.5
         }
         
-        let firstZoomLevel = minZoom + weightLevels.first.rawValue
-        let secondZoomLevel = minZoom + weightLevels.second.rawValue
-        let thirdZoomLevel = minZoom + weightLevels.third.rawValue
+        //let firstZoomLevel = minZoom + weightLevels.first.rawValue
+        //let secondZoomLevel = minZoom + weightLevels.second.rawValue
+        //let thirdZoomLevel = minZoom + weightLevels.third.rawValue
         let fourthZoomLevel = minZoom + weightLevels.fourth.rawValue
-        let fifthZoomLevel = minZoom + weightLevels.fifth.rawValue
+        //let fifthZoomLevel = minZoom + weightLevels.fifth.rawValue
         
         switch currentZoom {
-            case let x where x >= minZoom && x < firstZoomLevel:
+            case let x where x >= minZoom && x < fourthZoomLevel:
                 //Don't show annotations
                 return []
-            case let x where x >= firstZoomLevel && x < secondZoomLevel:
+            /*case let x where x >= firstZoomLevel && x < secondZoomLevel:
                 //Show the middle annotation
                 return [busStopAnnotations[busStopAnnotations.count/2]]
-            case let x where x >= secondZoomLevel && x < thirdZoomLevel:
+            */
+            /*case let x where x >= secondZoomLevel && x < thirdZoomLevel:
                 modN = 8
                 break
             case let x where x >= thirdZoomLevel && x < fourthZoomLevel:
@@ -305,6 +306,7 @@ class MyBusMapView: MGLMapView{
             case let x where x >= fourthZoomLevel && x < fifthZoomLevel:
                 modN = 2
                 break
+            */
             default:
                 modN = 1
         }

--- a/MyBus/MyBus/MyBusMapView.swift
+++ b/MyBus/MyBus/MyBusMapView.swift
@@ -283,30 +283,12 @@ class MyBusMapView: MGLMapView{
             case fifth = 4.5
         }
         
-        //let firstZoomLevel = minZoom + weightLevels.first.rawValue
-        //let secondZoomLevel = minZoom + weightLevels.second.rawValue
-        //let thirdZoomLevel = minZoom + weightLevels.third.rawValue
         let fourthZoomLevel = minZoom + weightLevels.fourth.rawValue
-        //let fifthZoomLevel = minZoom + weightLevels.fifth.rawValue
         
         switch currentZoom {
             case let x where x >= minZoom && x < fourthZoomLevel:
                 //Don't show annotations
                 return []
-            /*case let x where x >= firstZoomLevel && x < secondZoomLevel:
-                //Show the middle annotation
-                return [busStopAnnotations[busStopAnnotations.count/2]]
-            */
-            /*case let x where x >= secondZoomLevel && x < thirdZoomLevel:
-                modN = 8
-                break
-            case let x where x >= thirdZoomLevel && x < fourthZoomLevel:
-                modN = 4
-                break
-            case let x where x >= fourthZoomLevel && x < fifthZoomLevel:
-                modN = 2
-                break
-            */
             default:
                 modN = 1
         }


### PR DESCRIPTION
This PR solves ticket MYB-409 that was a bug that didn't show the navbar after dragging an annotation.

It also solves an observation from the product owner by not showing the annotations progressively but to hide/show all of them according to a zoom threshold barrier

![navbar](https://cloud.githubusercontent.com/assets/5022588/20810693/7a29e47a-b7e9-11e6-93bc-8c2a0f35dbc9.gif)
